### PR TITLE
Use pysha3 on python<3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "bech32==1.2.0",
     "mnemonic==0.20",
     "hdwallets==0.1.2",
-    "safe-pysha3==1.0.3"
+    "safe-pysha3==1.0.3;python_version>='3.9'",
+    "pysha3==1.0.2;python_version<'3.9'",
 ]
 dynamic = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ hdwallets==0.1.2
 httpx==0.23.0
 mnemonic==0.20
 protobuf==4.22.1
-safe-pysha3==1.0.3
+safe-pysha3==1.0.3;python_version>='3.9'
+pysha3==1.0.2;python_version<'3.9'


### PR DESCRIPTION
Looks like safe-pysha3 is only compatible with python3.9 and above, so I added specifiers to select the dependency depending on python version.