### PR TITLE
mospy sentinel chain

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bech32==1.2.0
-cosmospy_protobuf>=0.2.0
+sentinel_protobuf>=0.3.3
 ecdsa==0.17.0
 grpcio~=1.47.0
 hdwallets==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bech32==1.2.0
-sentinel_protobuf>=0.3.3
+cosmospy_protobuf>=0.2.0
 ecdsa==0.17.0
 grpcio~=1.47.0
 hdwallets==0.1.2

--- a/src/mospy/Account.py
+++ b/src/mospy/Account.py
@@ -51,6 +51,7 @@ class Account:
             "cosmos": "cosmospy_protobuf",
             "osmosis": "osmosis_protobuf",
             "evmos": "evmos_protobuf",
+            "sentinel": "sentinel_protobuf",
         }
         _protobuf_package = (_protobuf_packages[protobuf.lower()]
                              if protobuf.lower() in _protobuf_packages.keys()

--- a/src/mospy/Transaction.py
+++ b/src/mospy/Transaction.py
@@ -45,6 +45,7 @@ class Transaction:
             "cosmos": "cosmospy_protobuf",
             "osmosis": "osmosis_protobuf",
             "evmos": "evmos_protobuf",
+            "sentinel": "sentinel_protobuf",
         }
         self._protobuf_package = (_protobuf_packages[protobuf.lower()]
                                   if protobuf.lower()

--- a/src/mospy/clients/GRPCClient.py
+++ b/src/mospy/clients/GRPCClient.py
@@ -32,6 +32,7 @@ class GRPCClient:
             "cosmos": "cosmospy_protobuf",
             "osmosis": "osmosis_protobuf",
             "evmos": "evmos_protobuf",
+            "sentinel": "sentinel_protobuf",
         }
         _protobuf_package = (_protobuf_packages[protobuf.lower()]
                              if protobuf.lower() in _protobuf_packages.keys()


### PR DESCRIPTION
Hello Felix, first of all thank for your awesome work! :heart: 
We are developing a `sentinel_sdk` in python and I had to add the `sentinel_protobuf` inside **mospy**.

Currently the `sentinel_protobuf` is maintained by @MathNodes. I saw that 2 weeks ago you accept the PR https://github.com/ctrl-Felix/cosmospy-protobuf/pull/14, but the pypi release is Nov 27, 2023 (without the `sentinel_protobuf`).

I had to change the requirements from `cosmospy_protobuf` to `sentinel_protobuf`.
Now we have two options:
1. Continue to maintain separate the protobuf and mospy package, obviously will be create a pypi package `sentinel_mospy`
2. Pubblish on pypi the latest version of `cosmospy_protobuf` (that include also sentinel) and the release an update also for `mospy` (this PR - with the requirements.txt rollbacked to `cosmospy_protobuf`)

What do you think?

~~The PR include also a `GetTx` method, out of sentinel/chain related scope.~~