### PR TITLE
OpenSSL <3.0 ripemd160 bugfix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mnemonic==0.20
 protobuf==4.22.1
 safe-pysha3==1.0.3;python_version>='3.9'
 pysha3==1.0.2;python_version<'3.9'
+pycryptodome==3.20.0

--- a/src/mospy/utils.py
+++ b/src/mospy/utils.py
@@ -6,6 +6,7 @@ import bech32
 from mnemonic import Mnemonic
 from sha3 import keccak_256
 import binascii
+from Crypto.Hash.RIPEMD160 import new as ripemd160_new
 
 
 def seed_to_private_key(seed, derivation_path, passphrase: str = ""):
@@ -26,7 +27,9 @@ def privkey_to_pubkey(privkey: bytes, raw: bool = False) -> bytes:
 
 def pubkey_to_address(pubkey: bytes, *, hrp: str) -> str:
     s = hashlib.new("sha256", pubkey).digest()
-    r = hashlib.new("ripemd160", s).digest()
+    ripemd160 = ripemd160_new()
+    ripemd160.update(s)
+    r = ripemd160.digest()
     five_bit_r = bech32.convertbits(r, 8, 5)
     assert five_bit_r is not None, "Unsuccessful bech32.convertbits call"
     return bech32.bech32_encode(hrp, five_bit_r)


### PR DESCRIPTION
Solution to a popular problem: https://stackoverflow.com/questions/72409563/unsupported-hash-type-ripemd160-with-hashlib-in-python